### PR TITLE
remove ampersand effect syntax

### DIFF
--- a/test/Test01.flix
+++ b/test/Test01.flix
@@ -19,7 +19,7 @@ mod Test01 {
         tr(colspan_(2) :: Nil, text("...")) |> toString
 
 
-    pub def runTests(): Unit & Impure =
+    pub def runTests(): Unit \ IO =
         test01() |> println;
         test02() |> println
         


### PR DESCRIPTION
This syntax is being removed from Flix. Likely more effect syntax changes are to come, but the `\` syntax is the current one.