### PR TITLE
fix: add space between tag and attribute

### DIFF
--- a/src/Text/HtmlDoc.flix
+++ b/src/Text/HtmlDoc.flix
@@ -95,7 +95,7 @@ mod Text.HtmlDoc {
 
     def ppOpeningTag(name: String, attrs: List[HtmlAttr]): Doc = match attrs {
         case Nil => ppText("<" ++ name ++ ">")
-        case _   => group(encloseSep(ppText("<" ++ name), ppChar('>'), ppEmpty(), List.map(ppAttr, attrs)))
+        case _   => group(encloseSep(ppText("<" ++ name + " "), ppChar('>'), ppEmpty(), List.map(ppAttr, attrs)))
     }
 
     def ppClosingTag(name: String): Doc = ppText("</" ++ name ++ ">")

--- a/test/Test01.flix
+++ b/test/Test01.flix
@@ -40,4 +40,23 @@ mod Test01 {
         use Text.HtmlDoc.{<&&>, link0};
         (link0(Nil) <&&> link0(Nil)) |> toString |> println
 
+    @test
+    def test07(): Unit \ IO =
+        use Text.HtmlDoc.{anchor, HtmlAttr, text};
+        anchor(List#{HtmlAttr.HtmlAttr("href", "https://example.com")}, text("Click me!")) |> toString |> println
+
+    @test
+    def test08(): Unit \ IO =
+        use Text.HtmlDoc.{anchor, HtmlAttr, text};
+        anchor(List#{HtmlAttr.HtmlAttrBoolean("download")}, text("Click me!")) |> toString |> println
+
+    @test
+    def test09(): Unit \ IO =
+        use Text.HtmlDoc.{anchor, HtmlAttr, text};
+        anchor(List#{HtmlAttr.HtmlAttr("href", "https://example.com"), HtmlAttr.HtmlAttrBoolean("download")}, text("Click me!")) |> toString |> println
+
+    @test
+    def test10(): Unit \ IO =
+        use Text.HtmlDoc.{anchor, HtmlAttr, text};
+        anchor(List#{HtmlAttr.HtmlAttrBoolean("download"), HtmlAttr.HtmlAttr("href", "https://example.com")}, text("Click me!")) |> toString |> println
 }


### PR DESCRIPTION
Recent changes introduced a problem where there is no space between a tag name and an attribute, for example:
```
<ahref="example.com">Blah</a>
 ^^^^^
```

This change adds a space where needed. I'm not sure if it's the right fix; maybe some combinator in the Pretty library is more appropriate. But this works for my use-case.

I added a few visual tests as well.